### PR TITLE
Fix/6339 js dialog

### DIFF
--- a/modules/sharedaddy/sharing-service.php
+++ b/modules/sharedaddy/sharing-service.php
@@ -548,9 +548,7 @@ function sharing_add_footer() {
 		);
 		wp_localize_script( 'sharing-js', 'sharing_js_options', $sharing_js_options);
 	}
-}
 
-function sharing_add_footer_scripts_inline() {
 	$sharer = new Sharing_Service();
 	$enabled = $sharer->get_blog_services();
 	foreach ( array_merge( $enabled['visible'], $enabled['hidden'] ) AS $service ) {
@@ -779,9 +777,6 @@ function sharing_display( $text = '', $echo = false ) {
 
 			// Enqueue scripts for the footer
 			add_action( 'wp_footer', 'sharing_add_footer' );
-
-			// Print inline scripts that depend on jQuery
-			add_action( 'wp_footer', 'sharing_add_footer_scripts_inline', 25 );
 		}
 	}
 

--- a/modules/sharedaddy/sharing-sources.php
+++ b/modules/sharedaddy/sharing-sources.php
@@ -516,7 +516,6 @@ class Share_Email extends Sharing_Source {
 
 			<?php endif; ?>
 			<input type="text" id="jetpack-source_f_name" name="source_f_name" class="input" value="" size="25" autocomplete="off" title="<?php esc_attr_e( 'This field is for validation and should not be changed', 'jetpack' ); ?>" />
-			<script>jQuery( document ).ready( function(){ document.getElementById('jetpack-source_f_name').value = '' });</script>
 			<?php
 				/**
 				 * Fires when the Email sharing dialog is loaded.

--- a/modules/sharedaddy/sharing-sources.php
+++ b/modules/sharedaddy/sharing-sources.php
@@ -1547,7 +1547,7 @@ class Share_Pinterest extends Sharing_Source {
 		$jetpack_pinit_over = apply_filters( 'jetpack_pinit_over_button', true );
 
 		if ( $jetpack_pinit_over ) {
-			$jetpack_pinit_over_js = 's.setAttribute("data-pin-hover", true);';
+			$jetpack_pinit_over_js = "s.setAttribute( 'data-pin-hover', true );";
 		} else {
 			$jetpack_pinit_over_js = '';
 		}

--- a/modules/sharedaddy/sharing-sources.php
+++ b/modules/sharedaddy/sharing-sources.php
@@ -340,21 +340,18 @@ abstract class Sharing_Source {
 		foreach ( $params as $key => $val ) {
 			$opts[] = "$key=$val";
 		}
-		$opts = implode( ',', $opts );
+
+		$dialog_settings = array(
+			'name' => $name,
+			'windowOpts' => implode( ',', $opts ),
+		);
 
 		// Add JS after sharing-js has been enqueued.
 		wp_add_inline_script( 'sharing-js',
-			"
-			var windowOpen;
-			jQuery( document.body ).on( 'click', 'a.share-$name', function() {
-				// If there's another sharing window open, close it.
-				if ( 'undefined' !== typeof windowOpen ) {
-					windowOpen.close();
-				}
-				windowOpen = window.open( jQuery( this ).attr( 'href' ), 'wpcom$name', '$opts' );
-				return false;
-			});
-			"
+			sprintf(
+				"jQuery( document ).trigger( 'jetpack-sharing-window-init', [ %s ] );",
+				wp_json_encode( $dialog_settings )
+			)
 		);
 	}
 }

--- a/modules/sharedaddy/sharing-sources.php
+++ b/modules/sharedaddy/sharing-sources.php
@@ -985,16 +985,22 @@ class Share_Facebook extends Sharing_Source {
 			} else {
 				$fb_app_id = '';
 			}
-			?><div id="fb-root"></div>
-			<script>(function(d, s, id) { var js, fjs = d.getElementsByTagName(s)[0]; if (d.getElementById(id)) return; js = d.createElement(s); js.id = id; js.src = 'https://connect.facebook.net/<?php echo $locale; ?>/sdk.js#xfbml=1<?php echo $fb_app_id; ?>&version=v2.3'; fjs.parentNode.insertBefore(js, fjs); }(document, 'script', 'facebook-jssdk'));</script>
-			<script>
-			jQuery( document.body ).on( 'post-load', function() {
-				if ( 'undefined' !== typeof FB ) {
-					FB.XFBML.parse();
-				}
-			} );
-			</script>
-			<?php
+
+			echo '<div id="fb-root"></div>';
+
+			wp_add_inline_script( 'sharing-js',
+				"
+				(function(d, s, id) { var js, fjs = d.getElementsByTagName(s)[0]; if (d.getElementById(id)) return; js = d.createElement(s); js.id = id; js.src = 'https://connect.facebook.net/$locale/sdk.js#xfbml=1$fb_app_id&version=v2.3'; fjs.parentNode.insertBefore(js, fjs); }(document, 'script', 'facebook-jssdk'));
+				jQuery( document.body ).on( 'post-load', function() {
+					if ( 'undefined' !== typeof FB ) {
+						FB.XFBML.parse();
+					}
+				} );
+				"
+			);
+
+		} else {
+			$this->js_dialog( $this->shortname );
 		}
 	}
 }
@@ -1007,7 +1013,7 @@ class Share_Print extends Sharing_Source {
 
 		if ( 'official' == $this->button_style ) {
 			$this->smart = true;
-		} else { 
+		} else {
 			$this->smart = false;
 		}
 	}

--- a/modules/sharedaddy/sharing-sources.php
+++ b/modules/sharedaddy/sharing-sources.php
@@ -1567,28 +1567,8 @@ class Share_Pinterest extends Sharing_Source {
 				jQuery(window).load( function(){ jQuery( 'li.share-pinterest a span:visible' ).closest( '.share-pinterest' ).width( '80px' ); } );
 				"
 			);
-		elseif ( 'buttonPin' != $this->get_widget_type() ) :
-			wp_add_inline_script( 'sharing-js',
-				"
-				jQuery(document).ready( function(){
-					jQuery('body').on('click', 'a.share-pinterest', function(e){
-						e.preventDefault();
-						// Load Pinterest Bookmarklet code
-						var s = document.createElement('script');
-						s.type = 'text/javascript';
-						s.src = window.location.protocol + '//assets.pinterest.com/js/pinmarklet.js?r=' + ( Math.random() * 99999999 );
-						var x = document.getElementsByTagName('script')[0];
-						x.parentNode.insertBefore(s, x);
-						// Trigger Stats
-						var s = document.createElement('script');
-						s.type = 'text/javascript';
-						s.src = this + ( this.toString().indexOf( '?' ) ? '&' : '?' ) + 'js_only=1';
-						var x = document.getElementsByTagName('script')[0];
-						x.parentNode.insertBefore(s, x);
-					});
-				});
-				"
-			);
+		else :
+			$this->js_dialog( $this->shortname, array( 'width' => 750, 'height' => 620 ) );
 		endif;
 	}
 }

--- a/modules/sharedaddy/sharing-sources.php
+++ b/modules/sharedaddy/sharing-sources.php
@@ -344,7 +344,8 @@ abstract class Sharing_Source {
 
 		// Add JS after sharing-js has been enqueued.
 		wp_add_inline_script( 'sharing-js',
-			"var windowOpen;
+			"
+			var windowOpen;
 			jQuery( document.body ).on( 'click', 'a.share-$name', function() {
 				// If there's another sharing window open, close it.
 				if ( 'undefined' !== typeof windowOpen ) {
@@ -352,7 +353,8 @@ abstract class Sharing_Source {
 				}
 				windowOpen = window.open( jQuery( this ).attr( 'href' ), 'wpcom$name', '$opts' );
 				return false;
-			});"
+			});
+			"
 		);
 	}
 }
@@ -1138,39 +1140,40 @@ class Share_GooglePlus1 extends Sharing_Source {
 	public function display_footer() {
 		global $post;
 
-		if ( $this->smart ) { ?>
-			<script>
-			function renderGooglePlus1() {
-				if ( 'undefined' === typeof gapi ) {
-					return;
+		if ( $this->smart ) {
+			wp_add_inline_script( 'sharing-js',
+				"
+				function renderGooglePlus1() {
+					if ( 'undefined' === typeof gapi ) {
+						return;
+					}
+
+					jQuery( '.g-plus' ).each(function() {
+						var $button = jQuery( this );
+
+						if ( ! $button.data( 'gplus-rendered' ) ) {
+							gapi.plusone.render( this, {
+								href: $button.attr( 'data-href' ),
+								size: $button.attr( 'data-size' ),
+								annotation: $button.attr( 'data-annotation' )
+							});
+
+							$button.data( 'gplus-rendered', true );
+						}
+					});
 				}
 
-				jQuery( '.g-plus' ).each(function() {
-					var $button = jQuery( this );
+				(function() {
+					var po = document.createElement('script'); po.type = 'text/javascript'; po.async = true;
+					po.src = 'https://apis.google.com/js/plusone.js';
+					po.innerHTML = '{\"parsetags\": \"explicit\"}';
+					po.onload = renderGooglePlus1;
+					var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(po, s);
+				})();
 
-					if ( ! $button.data( 'gplus-rendered' ) ) {
-						gapi.plusone.render( this, {
-							href: $button.attr( 'data-href' ),
-							size: $button.attr( 'data-size' ),
-							annotation: $button.attr( 'data-annotation' )
-						});
-
-						$button.data( 'gplus-rendered', true );
-					}
-				});
-			}
-
-			(function() {
-				var po = document.createElement('script'); po.type = 'text/javascript'; po.async = true;
-				po.src = 'https://apis.google.com/js/plusone.js';
-				po.innerHTML = '{"parsetags": "explicit"}';
-				po.onload = renderGooglePlus1;
-				var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(po, s);
-			})();
-
-			jQuery( document.body ).on( 'post-load', renderGooglePlus1 );
-			</script>
-			<?php
+				jQuery( document.body ).on( 'post-load', renderGooglePlus1 );
+				"
+			);
 		} else {
 			$this->js_dialog( 'google-plus-1', array( 'width' => 480, 'height' => 550 ) );
 		}
@@ -1545,43 +1548,51 @@ class Share_Pinterest extends Sharing_Source {
 		 * @param bool $jetpack_pinit_over True by default, displays the Pin it button when hovering over images.
 		 */
 		$jetpack_pinit_over = apply_filters( 'jetpack_pinit_over_button', true );
-		?>
-		<?php if ( $this->smart ) : ?>
-			<script type="text/javascript">
+
+		if ( $jetpack_pinit_over ) {
+			$jetpack_pinit_over_js = 's.setAttribute("data-pin-hover", true);';
+		} else {
+			$jetpack_pinit_over_js = '';
+		}
+
+		if ( $this->smart ) :
+			wp_add_inline_script( 'sharing-js',
+				"
 				// Pinterest shared resources
-				var s = document.createElement("script");
-				s.type = "text/javascript";
+				var s = document.createElement('script');
+				s.type = 'text/javascript';
 				s.async = true;
-				<?php if ( $jetpack_pinit_over ) { 
-				echo "s.setAttribute('data-pin-hover', true);";
-				} ?>
-				s.src = window.location.protocol + "//assets.pinterest.com/js/pinit.js";
-				var x = document.getElementsByTagName("script")[0];
+				$jetpack_pinit_over_js
+				s.src = window.location.protocol + '//assets.pinterest.com/js/pinit.js';
+				var x = document.getElementsByTagName('script')[0];
 				x.parentNode.insertBefore(s, x);
 				// if 'Pin it' button has 'counts' make container wider
 				jQuery(window).load( function(){ jQuery( 'li.share-pinterest a span:visible' ).closest( '.share-pinterest' ).width( '80px' ); } );
-			</script>
-		<?php elseif ( 'buttonPin' != $this->get_widget_type() ) : ?>
-			<script type="text/javascript">
+				"
+			);
+		elseif ( 'buttonPin' != $this->get_widget_type() ) :
+			wp_add_inline_script( 'sharing-js',
+				"
 				jQuery(document).ready( function(){
 					jQuery('body').on('click', 'a.share-pinterest', function(e){
 						e.preventDefault();
 						// Load Pinterest Bookmarklet code
-						var s = document.createElement("script");
-						s.type = "text/javascript";
-						s.src = window.location.protocol + "//assets.pinterest.com/js/pinmarklet.js?r=" + ( Math.random() * 99999999 );
-						var x = document.getElementsByTagName("script")[0];
+						var s = document.createElement('script');
+						s.type = 'text/javascript';
+						s.src = window.location.protocol + '//assets.pinterest.com/js/pinmarklet.js?r=' + ( Math.random() * 99999999 );
+						var x = document.getElementsByTagName('script')[0];
 						x.parentNode.insertBefore(s, x);
 						// Trigger Stats
-						var s = document.createElement("script");
-						s.type = "text/javascript";
+						var s = document.createElement('script');
+						s.type = 'text/javascript';
 						s.src = this + ( this.toString().indexOf( '?' ) ? '&' : '?' ) + 'js_only=1';
-						var x = document.getElementsByTagName("script")[0];
+						var x = document.getElementsByTagName('script')[0];
 						x.parentNode.insertBefore(s, x);
 					});
 				});
-			</script>
-		<?php endif;
+				"
+			);
+		endif;
 	}
 }
 
@@ -1594,7 +1605,7 @@ class Share_Pocket extends Sharing_Source {
 
 		if ( 'official' == $this->button_style ) {
 			$this->smart = true;
-		} else { 
+		} else {
 			$this->smart = false;
 		}
 	}
@@ -1630,16 +1641,16 @@ class Share_Pocket extends Sharing_Source {
 
 	function display_footer() {
 		if ( $this->smart ) :
-		?>
-		<script>
-		// Don't use Pocket's default JS as it we need to force init new Pocket share buttons loaded via JS.
-		function jetpack_sharing_pocket_init() {
-			jQuery.getScript( 'https://widgets.getpocket.com/v1/j/btn.js?v=1' );
-		}
-		jQuery( document ).ready( jetpack_sharing_pocket_init );
-		jQuery( document.body ).on( 'post-load', jetpack_sharing_pocket_init );
-		</script>
-		<?php
+			wp_add_inline_script( 'sharing-js',
+				"
+				// Don't use Pocket's default JS as it we need to force init new Pocket share buttons loaded via JS.
+				function jetpack_sharing_pocket_init() {
+					jQuery.getScript( 'https://widgets.getpocket.com/v1/j/btn.js?v=1' );
+				}
+				jQuery( document ).ready( jetpack_sharing_pocket_init );
+				jQuery( document.body ).on( 'post-load', jetpack_sharing_pocket_init );
+				"
+			);
 		else :
 			$this->js_dialog( $this->shortname, array( 'width' => 450, 'height' => 450 ) );
 		endif;

--- a/modules/sharedaddy/sharing-sources.php
+++ b/modules/sharedaddy/sharing-sources.php
@@ -1602,11 +1602,13 @@ class Share_Pocket extends Sharing_Source {
 
 	public function get_display( $post ) {
 		if ( $this->smart ) {
-			$post_count = 'horizontal';
-
 			$button = '';
 			$button .= '<div class="pocket_button">';
-			$button .= sprintf( '<a href="https://getpocket.com/save" class="pocket-btn" data-lang="%s" data-save-url="%s" data-pocket-count="%s" >%s</a>', 'en', esc_attr( $this->get_share_url( $post->ID ) ), $post_count, esc_attr__( 'Pocket', 'jetpack' ) );
+			$button .= sprintf(
+				'<a href="https://getpocket.com/save" class="pocket-btn" data-lang="en" data-save-url="%s" data-pocket-count="horizontal">%s</a>',
+				esc_attr( $this->get_share_url( $post->ID ) ),
+				esc_attr__( 'Pocket', 'jetpack' )
+			);
 			$button .= '</div>';
 
 			return $button;

--- a/modules/sharedaddy/sharing-sources.php
+++ b/modules/sharedaddy/sharing-sources.php
@@ -844,20 +844,22 @@ class Share_LinkedIn extends Sharing_Source {
 	}
 
 	public function display_footer() {
-		if ( ! $this->smart ) {
-			$this->js_dialog( $this->shortname, array( 'width' => 580, 'height' => 450 ) );
-		} else {
-			?><script type="text/javascript">
-			jQuery( document ).ready( function() {
-				jQuery.getScript( 'https://platform.linkedin.com/in.js?async=true', function success() {
-					IN.init();
+		if ( $this->smart ) {
+			wp_add_inline_script( 'sharing-js',
+				"
+				jQuery( document ).ready( function() {
+					jQuery.getScript( 'https://platform.linkedin.com/in.js?async=true', function success() {
+						IN.init();
+					});
 				});
-			});
-			jQuery( document.body ).on( 'post-load', function() {
-				if ( typeof IN != 'undefined' )
-					IN.parse();
-			});
-			</script><?php
+				jQuery( document.body ).on( 'post-load', function() {
+					if ( typeof IN != 'undefined' )
+						IN.parse();
+				});
+				"
+			);
+		} else {
+			$this->js_dialog( $this->shortname, array( 'width' => 580, 'height' => 450 ) );
 		}
 	}
 }

--- a/modules/sharedaddy/sharing-sources.php
+++ b/modules/sharedaddy/sharing-sources.php
@@ -1149,16 +1149,16 @@ class Share_GooglePlus1 extends Sharing_Source {
 					}
 
 					jQuery( '.g-plus' ).each(function() {
-						var $button = jQuery( this );
+						var \$button = jQuery( this );
 
-						if ( ! $button.data( 'gplus-rendered' ) ) {
+						if ( ! \$button.data( 'gplus-rendered' ) ) {
 							gapi.plusone.render( this, {
-								href: $button.attr( 'data-href' ),
-								size: $button.attr( 'data-size' ),
-								annotation: $button.attr( 'data-annotation' )
+								href: \$button.attr( 'data-href' ),
+								size: \$button.attr( 'data-size' ),
+								annotation: \$button.attr( 'data-annotation' )
 							});
 
-							$button.data( 'gplus-rendered', true );
+							\$button.data( 'gplus-rendered', true );
 						}
 					});
 				}

--- a/modules/sharedaddy/sharing.js
+++ b/modules/sharedaddy/sharing.js
@@ -120,12 +120,23 @@ var updateLinkedInCount = function( data ) {
 };
 
 (function($){
-	var $body, $sharing_email;
+	var $body, $sharing_email, sharingWindowOpen;
 
 	$.fn.extend( {
 		share_is_email: function() {
 			return /^((([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+(\.([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+)*)|((\x22)((((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(([\x01-\x08\x0b\x0c\x0e-\x1f\x7f]|\x21|[\x23-\x5b]|[\x5d-\x7e]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(\\([\x01-\x09\x0b\x0c\x0d-\x7f]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]))))*(((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(\x22)))@((([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.)+(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.?$/i.test( this.val() );
 		}
+	} );
+
+	$( document ).on( 'jetpack-sharing-window-init', function( event, params ) {
+		$( document ).on( 'click', 'a.share-' + params.name, function() {
+			// If there's another sharing window open, close it.
+			if ( 'undefined' !== typeof sharingWindowOpen ) {
+				sharingWindowOpen.close();
+			}
+			sharingWindowOpen = window.open( jQuery( this ).attr( 'href' ), 'wpcom' + params.name, params.windowOpts );
+			return false;
+		});
 	} );
 
 	$body = $( document.body ).on( 'post-load', WPCOMSharing_do );


### PR DESCRIPTION
Wraps inline JS in `wp_add_inline_script()` for the following sharing providers:

- Google+ "smart" sharing
- Pinterest "smart" and non-buttonPin widget type
- Pocket "smart" sharing